### PR TITLE
do not mount /var/run/postgresql twice, already mounted as tmpfs

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,7 +12,6 @@ services:
       - "${POSTGRES_PORT:-5433}:5432"
     volumes:
       - postgres_data_dev:/var/lib/postgresql/data
-      - postgres_run_dev:/var/run/postgresql
       - ./init-db:/docker-entrypoint-initdb.d:ro
     networks:
       - appointment-booking-dev
@@ -42,8 +41,6 @@ services:
 
 volumes:
   postgres_data_dev:
-    driver: local
-  postgres_run_dev:
     driver: local
 
 networks:


### PR DESCRIPTION
- /var/run/postgresql is already mounted as tmpfs
- second mount as volume leaded to error when booting up docker dev environment