### PR TITLE
Make user confirmation idempotent

### DIFF
--- a/src/lib/server/services/user-service.ts
+++ b/src/lib/server/services/user-service.ts
@@ -291,6 +291,7 @@ export class UserService {
             tenantId: string | null;
             role: "GLOBAL_ADMIN" | "TENANT_ADMIN" | "STAFF";
             email: string;
+            used?: boolean;
           }
         | undefined = undefined;
 
@@ -320,6 +321,7 @@ export class UserService {
             email: centralSchema.userInvite.email,
             name: centralSchema.userInvite.name,
             language: centralSchema.userInvite.language,
+            used: centralSchema.userInvite.used,
           })
           .from(centralSchema.userInvite)
           .where(
@@ -337,6 +339,26 @@ export class UserService {
           throw new NotFoundError("Invalid or timed-out token");
         } else {
           resultData = { ...inviteData[0], recoveryPassphrase: null };
+          if (resultData.used) {
+            log.warn("User invite was already confirmed.", {
+              email: resultData.email,
+              tenantId: resultData.tenantId,
+            });
+            return {
+              recoveryPassphrase: undefined,
+              isSetup: false,
+              id: resultData.id,
+              email: resultData.email,
+              name: resultData.name,
+              language: resultData.language,
+              tenantId: resultData.tenantId,
+            };
+          }
+          log.info("User confirmation successful via invite", {
+            email: resultData.email,
+            tenantId: resultData.tenantId,
+          });
+
           const userDataForDb: InsertUser = {
             name: resultData.name!,
             email: resultData.email,


### PR DESCRIPTION
I tried to make this a little bit more reliable. My impression is that the invite confirmation actually gets fired more than once. I think this is due to the reason that calling the page (which is a GET request) internally calls the API (with a POST request). AI supported this assumption. 

This might happen for example due to scanning requests made by a Mail program (It's just a GET request, what will happen there?). So in conclusion maybe it would be more reliable to not implicitly call the confirmation when opening the page, but instead makes this a deliberate button press for the user? @karlludwigweise 