### PR TITLE
Calendar: show channel color in filter sidebar

### DIFF
--- a/src/lib/components/ui/checkbox-with-label/checkbox-with-label.svelte
+++ b/src/lib/components/ui/checkbox-with-label/checkbox-with-label.svelte
@@ -12,12 +12,15 @@
     class: className,
     value = $bindable(false),
     label,
+    color,
     tooltip,
     onCheckedChange,
     ...restProps
   }: HTMLAttributes<HTMLButtonElement> & {
     value: boolean;
     label: string;
+    /** Optional color (e.g. a channel color); shown as a dot before the label. */
+    color?: string | null;
     tooltip?: string;
     id?: string;
     onCheckedChange?: OnChangeFn<boolean>;
@@ -25,7 +28,7 @@
 </script>
 
 <label class={cn("flex items-center gap-2", className)}>
-  <div class="flex items-start gap-2">
+  <div class="flex min-w-0 items-start gap-2">
     <Checkbox
       {...restProps}
       checked={value}
@@ -33,7 +36,12 @@
       {onCheckedChange}
       class="mt-0.5"
     />
-    <Text style="sm" class="font-normal select-none">{label}</Text>
+    <Text style="sm" class="font-normal break-words select-none">
+      {#if color}<span
+          class="mr-1.5 inline-block size-2 shrink-0 rounded-full align-middle"
+          style="background-color: {color}"
+        ></span>{/if}{label}
+    </Text>
   </div>
   {#if tooltip}
     <Popover.Root>

--- a/src/routes/(pages)/dashboard/calendar/(components)/CalendarFilters.svelte
+++ b/src/routes/(pages)/dashboard/calendar/(components)/CalendarFilters.svelte
@@ -186,6 +186,7 @@
                 <CheckboxWithLabel
                   value={shownChannels.includes(channel.id)}
                   label={name}
+                  color={channel.color}
                   onCheckedChange={(v) => {
                     if (v) {
                       shownChannels = [...shownChannels, channel.id];


### PR DESCRIPTION
Closes #307

## What

Show each channel's color as a small dot before its name in the calendar filter sidebar (`<CalendarFilters />`), so the filter list is consistent with the channel colors already used elsewhere in the calendar (e.g. `CalendarDay`).

## How

- Add an optional `color` prop to `CheckboxWithLabel`. When set, it renders a small rounded dot before the label. The dot is inline (`inline-block` + `align-middle`) so it flows with the text and stays at the start of the first line when a long name wraps.
- The label `Text` now uses `break-words` and the row uses `min-w-0` so long channel names wrap within the sidebar instead of overflowing (per the issue's wrap requirement).
- Pass `color={channel.color}` in `CalendarFilters`. The prop is optional (`string | null`), so the agents list and any other `CheckboxWithLabel` callers are unchanged.

Colors come from `channel.color` (the same field `CalendarDay` renders), so no new data is needed.

## Verification

- `npm run check` (svelte-check): 0 errors, 0 warnings.
- `prettier --check` and `eslint` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)