### PR TITLE
#289

### DIFF
--- a/src/lib/components/ui/form/form-field-errors.svelte
+++ b/src/lib/components/ui/form/form-field-errors.svelte
@@ -28,11 +28,9 @@
       {@render childrenProp({ errors, errorProps })}
     {:else}
       <Text style="xs">
-        <!-- {#each errors as error, index (error + index)}
+        {#each errors as error, index (error + index)}
           <div {...errorProps} class={cn(errorClasses)}>{error}</div>
-        {/each} -->
-
-        <div {...errorProps} class={cn(errorClasses)}>{errors?.[0]}</div>
+        {/each}
       </Text>
     {/if}
   {/snippet}

--- a/src/lib/components/ui/form/form-field-errors.svelte
+++ b/src/lib/components/ui/form/form-field-errors.svelte
@@ -28,9 +28,11 @@
       {@render childrenProp({ errors, errorProps })}
     {:else}
       <Text style="xs">
-        {#each errors as error (error)}
+        <!-- {#each errors as error, index (error + index)}
           <div {...errorProps} class={cn(errorClasses)}>{error}</div>
-        {/each}
+        {/each} -->
+
+        <div {...errorProps} class={cn(errorClasses)}>{errors?.[0]}</div>
       </Text>
     {/if}
   {/snippet}

--- a/src/routes/(pages)/dashboard/settings/(components)/edit-settings-form/schema.ts
+++ b/src/routes/(pages)/dashboard/settings/(components)/edit-settings-form/schema.ts
@@ -5,11 +5,24 @@ const optionalUrl = (errorMessage: string) =>
   z
     .union([
       z.literal(""),
-      z
-        .url({ message: errorMessage })
-        .refine((url) => url.startsWith("http://") || url.startsWith("https://"), {
-          message: errorMessage,
-        }),
+      // z
+      //   .url({ message: errorMessage })
+      //   .refine((url) => url.startsWith("http://") || url.startsWith("https://"), {
+      //     message: errorMessage,
+      //   }),
+      z.string().refine(
+        (val) => {
+          try {
+            // 1. Check if it's a valid URL structure
+            const url = new URL(val);
+            // 2. Check if it uses the correct HTTP protocols
+            return url.protocol === "http:" || url.protocol === "https:";
+          } catch {
+            return false; // Fails if not a valid URL structure
+          }
+        },
+        { message: errorMessage },
+      ),
     ])
     .optional();
 


### PR DESCRIPTION
fixed a bug in form-field-errors.svelte to prevent displaying multiple errors at the same time and duplicate errors with the same index which caused break form submit in settings page